### PR TITLE
Use event.key property and not event.keyCode

### DIFF
--- a/src/constants/TriggerKeys.ts
+++ b/src/constants/TriggerKeys.ts
@@ -1,6 +1,6 @@
 export const TriggerKeys = {
-  KEY_RETURN: 13,
-  KEY_ENTER: 14,
-  KEY_TAB: 9,
-  KEY_SPACE: 32,
+  KEY_RETURN: "Enter",
+  KEY_ENTER: "Enter",
+  KEY_TAB: "Tab",
+  KEY_SPACE: " ",
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,9 +8,9 @@ import { Language } from "./types/Language";
 import { TriggerKeys } from "./constants/TriggerKeys";
 import { getTransliterateSuggestions } from "./util/suggestions-util";
 
-const KEY_UP = 38;
-const KEY_DOWN = 40;
-const KEY_ESCAPE = 27;
+const KEY_UP = "ArrowUp";
+const KEY_DOWN = "ArrowDown";
+const KEY_ESCAPE = "Escape";
 
 const OPTION_LIST_Y_OFFSET = 10;
 const OPTION_LIST_MIN_WIDTH = 100;
@@ -179,11 +179,11 @@ export const ReactTransliterate = ({
     const helperVisible = options.length > 0;
 
     if (helperVisible) {
-      if (triggerKeys.includes(event.keyCode)) {
+      if (triggerKeys.includes(event.key)) {
         event.preventDefault();
         handleSelection(selection);
       } else {
-        switch (event.keyCode) {
+        switch (event.key) {
           case KEY_ESCAPE:
             event.preventDefault();
             reset();


### PR DESCRIPTION
The module makes use of keyCode property , which is deprecated and does not works in mobile based browsers.
Instead this commit replaces instances and constants to use event.key