### PR TITLE
Minor fix: change margin-left to 0px in .language-dropdown

### DIFF
--- a/example/src/index.css
+++ b/example/src/index.css
@@ -26,7 +26,7 @@ code {
   border: 0;
   box-shadow: 0 0 12px 0 #eee;
   padding-left: 15px;
-  margin-left: 15px;
+  margin-left: 0;
   padding-right: 32px;
   -webkit-appearance: none;
   -moz-appearance: none;


### PR DESCRIPTION
margin-left:0 centre aligns the language drop-down menu with the input and text-area.
